### PR TITLE
Add space-related rules

### DIFF
--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -20,8 +20,8 @@ module.exports = {
     'no-bitwise': 2,
     'no-console': 0,
     'no-multi-spaces': 2,
-    'no-unused-vars': [ 2, { args: 'none', ignoreRestSiblings: true, varsIgnorePattern: '^_' } ],
     'no-trailing-spaces': [ 2 ],
+    'no-unused-vars': [ 2, { args: 'none', ignoreRestSiblings: true, varsIgnorePattern: '^_' } ],
     'object-curly-spacing': [ 2, 'always' ],
     'semi': [ 2, 'always' ],
     'space-before-blocks': [ 2, 'always' ],
@@ -30,9 +30,9 @@ module.exports = {
       'named': 'never',
       'asyncArrow': 'always'
     } ],
+    'spaced-comment': [ 2, 'always' ],
     'space-in-parens': [ 'error', 'never' ],
     'space-infix-ops': 'error',
-    'spaced-comment': [ 2, 'always' ],
     'quotes': [ 2, 'single', { avoidEscape: true } ]
   }
 };

--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -30,6 +30,7 @@ module.exports = {
       'asyncArrow': 'always'
     } ],
     'space-in-parens': [ 'error', 'never' ],
+    'space-infix-ops': 'error',
     'spaced-comment': [ 2, 'always' ],
     'quotes': [ 2, 'single', { avoidEscape: true } ]
   }

--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -9,6 +9,7 @@ module.exports = {
     'eslint:recommended'
   ],
   rules: {
+    'array-bracket-spacing': [ 'error', 'always' ],
     'indent': [ 2, 2, {
       VariableDeclarator: { var: 2, let: 2, const: 3 },
       FunctionDeclaration: { body: 1, parameters: 2 },

--- a/test/es6/cls.js
+++ b/test/es6/cls.js
@@ -9,7 +9,7 @@ export class Foo extends Bar {
 
   foo = (d) => {
 
-    const [_, blub ] = Blub.blub(...d);
+    const [ _, blub ] = Blub.blub(...d);
 
     const foop = "Hello 'BLUB'";
 


### PR DESCRIPTION
This introduces the `space-infix-ops` and `array-bracket-spacing` rules which we enforce already in our codebase, e.g. https://github.com/camunda/camunda-modeler/pull/2534#discussion_r738081833

Cf. https://eslint.org/docs/rules/space-infix-ops, https://eslint.org/docs/rules/array-bracket-spacing#always