### PR TITLE
fix: fine-tune `jsx` rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [eslint-plugin-bpmn-io](https://github.com/bpmn-io/eslint
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.0.2
+
+* `FIX`: fine-tune `jsx` rules
+
 ## 2.0.1
 
 * `FIX`: fine-tune `mocha` rules ([#21](https://github.com/bpmn-io/eslint-plugin-bpmn-io/pull/21))

--- a/configs/jsx.js
+++ b/configs/jsx.js
@@ -4,6 +4,8 @@ export default [
   reactPlugin.configs.flat.recommended,
   {
     rules: {
+      'react/no-unknown-property': [ 'error', { ignore: [ 'class' ] } ],
+      'react/react-in-jsx-scope': 'off',
       'jsx-quotes': ['error', 'prefer-double'],
       'react/jsx-curly-spacing': ['error', { when: 'always' }],
       'react/jsx-equals-spacing': 'error',

--- a/test/custom/fixtures/errors.js
+++ b/test/custom/fixtures/errors.js
@@ -34,7 +34,7 @@ export async function foo() {
 
   new URLSearchParams('foo=bar');
 
-  const component = <Foo_component />; // eslint-disable-line react/jsx-pascal-case, react/react-in-jsx-scope
+  const component = <Foo_component />; // eslint-disable-line react/jsx-pascal-case
 
   return {
     arrayBracketSpacing,

--- a/test/jsx/fixtures/errors.js
+++ b/test/jsx/fixtures/errors.js
@@ -2,7 +2,7 @@ import Foo_component from './FooComponent';
 
 export async function foo() {
 
-  const component = <Foo_component />; // eslint-disable-line react/jsx-pascal-case, react/react-in-jsx-scope
+  const component = <Foo_component />; // eslint-disable-line react/jsx-pascal-case
 
   return {
     component

--- a/test/jsx/fixtures/inferno.js
+++ b/test/jsx/fixtures/inferno.js
@@ -1,0 +1,7 @@
+import { Component } from 'inferno';
+
+export class Custom extends Component {
+  render() {
+    return <div class="container" />;
+  }
+}


### PR DESCRIPTION
This allows to use the config in non-React projects.

Related to https://github.com/bpmn-io/eslint-plugin-bpmn-io/issues/19#issuecomment-2407012924

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
