### PR TITLE
Implement ES2022 recommended ES version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [eslint-plugin-bpmn-io](https://github.com/bpmn-io/eslint
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.1.0
+
+* `FEAT`: support ES2022 per default ([#22](https://github.com/bpmn-io/eslint-plugin-bpmn-io/issues/24))
+
 ## 2.0.2
 
 * `FIX`: fine-tune `jsx` rules

--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -3,6 +3,11 @@ import js from '@eslint/js';
 export default [
   js.configs.recommended,
   {
+    languageOptions: {
+      ecmaVersion: 2022
+    }
+  },
+  {
     rules: {
       'array-bracket-spacing': ['error', 'always'],
       'indent': ['error', 2, {
@@ -14,7 +19,7 @@ export default [
       'lines-around-comment': ['error', {
         beforeBlockComment: true,
         beforeLineComment: true
-      } ],
+      }],
       'no-bitwise': 'error',
       'no-console': 'off',
       'no-constant-condition': ['error', {
@@ -27,7 +32,7 @@ export default [
         ignoreRestSiblings: true,
         varsIgnorePattern: '^_',
         caughtErrors: 'none'
-      } ],
+      }],
       'object-curly-spacing': ['error', 'always'],
       'semi': ['error', 'always'],
       'space-before-blocks': ['error', 'always'],

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "npm-run-all test:*",
+    "test": "run-p test:*",
     "test:browser": "eslint browser --config browser/eslint.config.js --report-unused-disable-directives",
     "test:custom": "eslint custom --config custom/eslint.config.js --report-unused-disable-directives",
     "test:jsx": "eslint jsx --config jsx/eslint.config.js --report-unused-disable-directives",

--- a/test/recommended/fixtures/es2019.js
+++ b/test/recommended/fixtures/es2019.js
@@ -1,0 +1,5 @@
+try {
+  2 + 2;
+} catch {
+  'no error';
+}

--- a/test/recommended/fixtures/es2020.js
+++ b/test/recommended/fixtures/es2020.js
@@ -1,0 +1,13 @@
+import.meta;
+
+export * as BarProp from './bar';
+
+BigInt(1);
+
+import('./dynamically');
+
+globalThis;
+
+const a = globalThis ?? 'default';
+
+a?.test;

--- a/test/recommended/fixtures/es2021.js
+++ b/test/recommended/fixtures/es2021.js
@@ -1,0 +1,22 @@
+function configExample(options) {
+  options.foo ??= true;
+  options.bar ??= 'baz';
+  return options;
+}
+
+configExample({ foo: false }); // { foo: false, bar: 'baz' }
+configExample({}); // { foo: true, bar: 'baz' }
+
+let logicalAnd = true;
+logicalAnd &&= false; // updated to false
+
+logicalAnd &&= true; // still false
+
+
+let logicalOr = false;
+logicalOr ||= true; // updated to true
+
+logicalOr ||= 'new'; // still true
+
+const a = new WeakRef({});
+a.deref();

--- a/test/recommended/fixtures/es2022.js
+++ b/test/recommended/fixtures/es2022.js
@@ -1,0 +1,33 @@
+function topLevel() {
+  return Promise.resolve();
+}
+
+await topLevel();
+
+class Foo {
+  static classField = 'Hello';
+
+  #privateClassField = 'World';
+
+  #privateMethod() {
+    return `${Foo.classField} ${this.#privateClassField}`;
+  }
+
+  publicMethod() {
+    return this.#privateMethod();
+  }
+}
+
+const a = new Foo;
+a.publicMethod();
+
+class ClassWithStaticInitializationBlock {
+  static staticProperty1 = 'Property 1';
+  static staticProperty2;
+  static {
+    this.staticProperty2 = 'Property 2';
+  }
+}
+
+ClassWithStaticInitializationBlock.staticProperty1;
+ClassWithStaticInitializationBlock.staticProperty2;


### PR DESCRIPTION
### Proposed Changes

This specifies ES2022 as the language version in `recommended`. The change is accompanied by the version-specific tests.

I've also changed the test setup to run in parallel as otherwise I had to do `npm run test:recommended -w test` in order to verify the new tests, because `nested.js` failed before them and stopped the test run in `npm t` case.

Closes #24

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
