### PR TITLE
feat: use shared node and browser globals in `recommended`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [eslint-plugin-bpmn-io](https://github.com/bpmn-io/eslint
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.2.0
+
+* `FEAT`: use shared node and browser globals in `recommended`
+
 ## 2.1.0
 
 * `FEAT`: support ES2022 per default ([#22](https://github.com/bpmn-io/eslint-plugin-bpmn-io/issues/24))

--- a/configs/recommended.js
+++ b/configs/recommended.js
@@ -1,10 +1,12 @@
 import js from '@eslint/js';
+import globals from 'globals';
 
 export default [
   js.configs.recommended,
   {
     languageOptions: {
-      ecmaVersion: 2022
+      ecmaVersion: 2022,
+      globals: globals['shared-node-browser']
     }
   },
   {

--- a/test/recommended/fixtures/misc.js
+++ b/test/recommended/fixtures/misc.js
@@ -35,3 +35,6 @@ export async function foo() {
 export function unusedArgs(unusedArg) {
   const _unusedVar = true;
 }
+
+console.log('test');
+new AbortController();


### PR DESCRIPTION
### Proposed Changes

Whenever we implement a cross-browser-node library, we run into an issue: _Should I use node, browser, or recommended eslint config?_
If we decide on `recommended`, this follows with problems around globals, e.g. [`console` is unavailable](https://github.com/bpmn-io/bpmnlint/pull/168/files#diff-63d99ff3dcb7713064d7147ffb7657f37a78df9028aa0caff8dca3c29e4d1a1cR136) because `recommended` does not allow any environment specific globals. However, we never run pure JavaScript and it's always either in the browser, or in Node.
My proposal is to embed the shared globals in the `recommended` ruleset. This will save us some frustration, and will make it easier to ship cross-browser-node libraries.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
